### PR TITLE
[Feat]: Support Lora Weight

### DIFF
--- a/bash_scripts/lora_inference.sh
+++ b/bash_scripts/lora_inference.sh
@@ -1,6 +1,7 @@
 python inference.py --plugin_type "lora" \
 --prompt "masterpiece, best quality, ultra detailed, 1 girl , solo, smile, looking at viewer, holding flowers"  \
 --prompt_sd1_5 "masterpiece, best quality, ultra detailed, 1 girl, solo, smile, looking at viewer, holding flowers, shuimobysim, wuchangshuo, bonian, zhenbanqiao, badashanren" \
+--lora_weight 1.0 \
 --adapter_guidance_start_list 0.95 \
 --adapter_condition_scale_list 1.50 \
 --seed 3943946911 \

--- a/inference.py
+++ b/inference.py
@@ -63,6 +63,10 @@ def parse_args(input_args=None):
         type=str, help='path to lora', default="./checkpoint/lora/MoXinV1.safetensors"
     )
     parser.add_argument(
+        "--lora_weight",
+        type=float, help='lora weight', default=1.0
+    )
+    parser.add_argument(
         "--prompt",
         type=str, help='SDXL prompt', default=None, required=True
     )

--- a/scripts/inference_lora.py
+++ b/scripts/inference_lora.py
@@ -124,6 +124,7 @@ def inference_lora(args):
     path_vae_sdxl = args.path_vae_sdxl
     adapter_path = args.adapter_checkpoint
     lora_model_path = args.lora_model_path
+    lora_weight = args.lora_weight
 
     prompt = args.prompt
     if args.prompt_sd1_5 is None:
@@ -222,7 +223,7 @@ def inference_lora(args):
             adapter=adapter,
         )
         # load lora
-        load_lora(pipe, lora_model_path, 1)
+        load_lora(pipe, lora_model_path, lora_weight)
         print('successfully load lora')
 
         pipe.to('cuda', weight_dtype)


### PR DESCRIPTION
What does this PR do? 
----
This PR takes the lora weight values and scales the learned weights of lora. The reason these weight values are needed is that some LoRA models require weight values lower than 1 to ensure the images do not break and are properly rendered. Adjusting the adapter_condition_scale value was not a solution.